### PR TITLE
fix for blank string cases in webgl

### DIFF
--- a/lib/get-simple-string.js
+++ b/lib/get-simple-string.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(a){
+  return (!a && a !== 0) ? '' : a.toString();
+}

--- a/lib/glyphs.js
+++ b/lib/glyphs.js
@@ -31,18 +31,12 @@ function getGlyph(symbol, font) {
     })
 
   //Calculate bounding box
-  var n = lineSymbol.positions.length
-
-  var bounds = [[-Infinity,-Infinity], [Infinity,Infinity]]
-
-  if (n > 0) {
-    bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
-    for(var i=0; i<n; ++i) {
-      var p = lineSymbol.positions[i]
-      for(var j=0; j<2; ++j) {
-        bounds[0][j] = Math.min(bounds[0][j], p[j])
-        bounds[1][j] = Math.max(bounds[1][j], p[j])
-      }
+  var bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
+  for(var i=0; i<lineSymbol.positions.length; ++i) {
+    var p = lineSymbol.positions[i]
+    for(var j=0; j<2; ++j) {
+      bounds[0][j] = Math.min(bounds[0][j], p[j])
+      bounds[1][j] = Math.max(bounds[1][j], p[j])
     }
   }
 

--- a/lib/glyphs.js
+++ b/lib/glyphs.js
@@ -28,7 +28,7 @@ function getGlyph(symbol, font) {
       textBaseline: "middle",
       lineHeight: 1.0,
       font: font
-    })
+    }) 
 
   //Calculate bounding box
   var bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]

--- a/lib/glyphs.js
+++ b/lib/glyphs.js
@@ -21,7 +21,7 @@ function getGlyph(symbol, font) {
       textBaseline: "middle",
       lineHeight: 1.0,
       font: font
-    }) 
+    })
   var triSymbol = vectorizeText(symbol, {
       triangles: true,
       textAlign: "center",
@@ -31,12 +31,18 @@ function getGlyph(symbol, font) {
     })
 
   //Calculate bounding box
-  var bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
-  for(var i=0; i<lineSymbol.positions.length; ++i) {
-    var p = lineSymbol.positions[i]
-    for(var j=0; j<2; ++j) {
-      bounds[0][j] = Math.min(bounds[0][j], p[j])
-      bounds[1][j] = Math.max(bounds[1][j], p[j])
+  var n = lineSymbol.positions.length
+
+  var bounds = [[-Infinity,-Infinity], [Infinity,Infinity]]
+
+  if (n > 0) {
+    bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
+    for(var i=0; i<n; ++i) {
+      var p = lineSymbol.positions[i]
+      for(var j=0; j<2; ++j) {
+        bounds[0][j] = Math.min(bounds[0][j], p[j])
+        bounds[1][j] = Math.max(bounds[1][j], p[j])
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1444,8 +1444,9 @@
       "dev": true
     },
     "is-string-blank": {
-      "version": "1.0.0",
-      "resolved": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
     },
     "is-symbol": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,6 +1443,10 @@
       "integrity": "sha1-DR5tk+OAs1OG9HRUP//Jpm1Bgl4=",
       "dev": true
     },
+    "is-string-blank": {
+      "version": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2",
+      "from": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2"
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1444,8 +1444,8 @@
       "dev": true
     },
     "is-string-blank": {
-      "version": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2",
-      "from": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2"
+      "version": "1.0.0",
+      "resolved": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2"
     },
     "is-symbol": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gl-vao": "^1.1.2",
     "glslify": "^6.1.0",
     "glsl-out-of-range": "^1.0.2",
-    "is-string-blank": "^1.0.0",
+    "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
     "vectorize-text": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gl-vao": "^1.1.2",
     "glslify": "^6.1.0",
     "glsl-out-of-range": "^1.0.2",
-    "is-string-blank": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2",
+    "is-string-blank": "^1.0.0",
     "typedarray-pool": "^1.0.2",
     "vectorize-text": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gl-vao": "^1.1.2",
     "glslify": "^6.1.0",
     "glsl-out-of-range": "^1.0.2",
+    "is-string-blank": "git://github.com/plotly/is-string-blank.git#6af8bd12913c0ed4ad3f19bc2142ab6aedc058f2",
     "typedarray-pool": "^1.0.2",
     "vectorize-text": "^3.0.0"
   },

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -514,12 +514,8 @@ proto.update = function(options) {
       var glyphLines  = glyphData.lines
       var glyphBounds = glyphData.bounds
 
-      if(glyphMesh.cells.length && glyphMesh.cells.length > 0) {
-        triVertexCount  += glyphMesh.cells.length * 3
-      }
-      if(glyphLines.edges.length && glyphLines.edges.length > 0) {
-        lineVertexCount += glyphLines.edges.length * 2
-      }
+      triVertexCount  += glyphMesh.cells.length * 3
+      lineVertexCount += glyphLines.edges.length * 2
     }
   }
 

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -1,12 +1,13 @@
 'use strict'
 
-var isAllBlank    = require('is-string-blank')
-var createBuffer  = require('gl-buffer')
-var createVAO     = require('gl-vao')
-var pool          = require('typedarray-pool')
-var mat4mult      = require('gl-mat4/multiply')
-var shaders       = require('./lib/shaders')
-var getGlyph      = require('./lib/glyphs')
+var isAllBlank      = require('is-string-blank')
+var createBuffer    = require('gl-buffer')
+var createVAO       = require('gl-vao')
+var pool            = require('typedarray-pool')
+var mat4mult        = require('gl-mat4/multiply')
+var shaders         = require('./lib/shaders')
+var getGlyph        = require('./lib/glyphs')
+var getSimpleString = require('./lib/get-simple-string')
 
 var IDENTITY = [1,0,0,0,
                 0,1,0,0,
@@ -404,19 +405,7 @@ function get_glyphData(glyphs, index, font) {
     str = glyphs
   }
 
-  // handle undefined and object cases
-  if(str === undefined) {
-    //str = 'undefined' // this line could be used for backward compatibility, I personally prefered to set this to N.A or null
-    str = ''
-  } else if(str === null) {
-    //str = 'null'
-    str = ''
-  } else if(typeof str === 'object') {
-    str = JSON.stringify(str, null, 1) // formatting object
-  } else {
-    str = str.toString()
-  }
-  // now everything is string
+  str = getSimpleString(str) // this would handle undefined cases
 
   var visible = true
   if(isAllBlank(str)) {

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var isAllBlank    = require('is-string-blank')
 var createBuffer  = require('gl-buffer')
 var createVAO     = require('gl-vao')
 var pool          = require('typedarray-pool')
@@ -389,22 +390,6 @@ proto.highlight = function(selection) {
   }
 }
 
-// https://github.com/plotly/fast-isnumeric/blob/efdd602521132349539fcf32161f4f62f10ea741/index.js#L29-L42
-function allBlankCharCodes(str){
-    var l = str.length,
-        a;
-    for(var i = 0; i < l; i++) {
-        a = str.charCodeAt(i);
-        if((a < 9 || a > 13) && (a !== 32) && (a !== 133) && (a !== 160) &&
-            (a !== 5760) && (a !== 6158) && (a < 8192 || a > 8205) &&
-            (a !== 8232) && (a !== 8233) && (a !== 8239) && (a !== 8287) &&
-            (a !== 8288) && (a !== 12288) && (a !== 65279)) {
-                return false;
-        }
-    }
-    return true;
-}
-
 function get_glyphData(glyphs, index, font) {
   var str
 
@@ -434,7 +419,7 @@ function get_glyphData(glyphs, index, font) {
   // now everything is string
 
   var visible = true
-  if(allBlankCharCodes(str)) {
+  if(isAllBlank(str)) {
     str = '▼' // Note: this special character may have minimum number of surfaces
     visible = false
   }

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -424,7 +424,7 @@ function get_glyphData(glyphs, index, font, fillBlank) {
     if(fillBlank) {
       str = '▼' // Note: it has minimum number of surfaces
     }
-    
+
     visible = false;
   }
 
@@ -538,14 +538,15 @@ proto.update = function(options) {
     }
   }
 
-  //Preallocate data
   var vertexCount   = triVertexCount + lineVertexCount
-  if(vertexCount > 0) {
-    var positionArray = pool.mallocFloat(3*vertexCount)
-    var colorArray    = pool.mallocFloat(4*vertexCount)
-    var glyphArray    = pool.mallocFloat(2*vertexCount)
-    var idArray       = pool.mallocUint32(vertexCount)
 
+  //Preallocate data
+  var positionArray = pool.mallocFloat(3*vertexCount)
+  var colorArray    = pool.mallocFloat(4*vertexCount)
+  var glyphArray    = pool.mallocFloat(2*vertexCount)
+  var idArray       = pool.mallocUint32(vertexCount)
+
+  if(vertexCount > 0) {
     var textOffset = [0,alignment[1]]
 
     var triOffset  = 0
@@ -571,7 +572,8 @@ proto.update = function(options) {
         lowerBound[j] = Math.min(lowerBound[j], x[j])
       }
 
-      var glyphData = get_glyphData(glyphs, i, font, false)
+      //var glyphData = get_glyphData(glyphs, i, font, false)
+      var glyphData = get_glyphData(glyphs, i, font, true)
 
       var glyphMesh   = glyphData.mesh
       var glyphLines  = glyphData.lines
@@ -639,7 +641,8 @@ proto.update = function(options) {
 
 
       var size = 0.5
-      if(Array.isArray(sizes)) {
+      if(!glyphVisible) size = 0.0
+      else if(Array.isArray(sizes)) {
         if(i < sizes.length) {
           size = +sizes[i]
         } else {
@@ -650,6 +653,7 @@ proto.update = function(options) {
       } else if(this.useOrtho) {
         size = 12
       }
+
 
       var angle = 0
       if(Array.isArray(angles)) {
@@ -723,38 +727,9 @@ proto.update = function(options) {
     }
 
 
-    //Update vertex counts
-    this.vertexCount      = triVertexCount
-    this.lineVertexCount  = lineVertexCount
-
-    //Update buffers
-    //if(0 < positionArray.length) {
-      this.pointBuffer.update(positionArray)
-    //}
-    //if(0 < colorArray.length) {
-      this.colorBuffer.update(colorArray)
-    //}
-    //if(0 < glyphArray.length) {
-      this.glyphBuffer.update(glyphArray)
-    //}
-    //if(0 < idArray.length) {
-      this.idBuffer.update(new Uint32Array(idArray))
-    //}
-
-    //if(0 < positionArray.length) {
-      pool.free(positionArray)
-    //}
-    //if(0 < colorArray.length) {
-      pool.free(colorArray)
-    //}
-    //if(0 < glyphArray.length) {
-      pool.free(glyphArray)
-    //}
-    //if(0 < idArray.length) {
-      pool.free(idArray)
-    //}
 
   }
+
   //Update bounds
   this.bounds = [lowerBound, upperBound]
 
@@ -763,6 +738,21 @@ proto.update = function(options) {
 
   //Save number of points
   this.pointCount = points.length
+
+  //Update vertex counts
+  this.vertexCount      = triVertexCount
+  this.lineVertexCount  = lineVertexCount
+
+  this.pointBuffer.update(positionArray)
+  this.colorBuffer.update(colorArray)
+  this.glyphBuffer.update(glyphArray)
+  //this.idBuffer.update(new Uint32Array(idArray))
+  this.idBuffer.update(idArray)
+
+  pool.free(positionArray)
+  pool.free(colorArray)
+  pool.free(glyphArray)
+  pool.free(idArray)
 }
 
 proto.dispose = function() {

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -474,13 +474,18 @@ count_loop:
     }
 
     var glyphData
+    var input = ''
     if(Array.isArray(glyphs)) {
-      glyphData = getGlyph(glyphs[i], font)
+      input  = glyphs[i]
     } else if(glyphs) {
-      glyphData = getGlyph(glyphs, font)
-    } else {
-      glyphData = getGlyph('●', font)
+      input  = glyphs
     }
+    if((input === '') ||
+       (input.length === input.replace(/[^ ]/g, '').length)) { // check for all blank case
+      input = '●'
+    }
+    glyphData = getGlyph(input, font)
+
     var glyphMesh   = glyphData[0]
     var glyphLines  = glyphData[1]
     var glyphBounds = glyphData[2]

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -389,8 +389,24 @@ proto.highlight = function(selection) {
   }
 }
 
-function get_glyphData(glyphs, index, font, fillBlank) {
-  var str;
+// https://github.com/plotly/fast-isnumeric/blob/efdd602521132349539fcf32161f4f62f10ea741/index.js#L29-L42
+function allBlankCharCodes(str){
+    var l = str.length,
+        a;
+    for(var i = 0; i < l; i++) {
+        a = str.charCodeAt(i);
+        if((a < 9 || a > 13) && (a !== 32) && (a !== 133) && (a !== 160) &&
+            (a !== 5760) && (a !== 6158) && (a < 8192 || a > 8205) &&
+            (a !== 8232) && (a !== 8233) && (a !== 8239) && (a !== 8287) &&
+            (a !== 8288) && (a !== 12288) && (a !== 65279)) {
+                return false;
+        }
+    }
+    return true;
+}
+
+function get_glyphData(glyphs, index, font) {
+  var str
 
   // use the data if presented in an array
   if(Array.isArray(glyphs)) {
@@ -417,15 +433,10 @@ function get_glyphData(glyphs, index, font, fillBlank) {
   }
   // now everything is string
 
-  var visible = true;
-  if((str === '') ||
-     (str.length === str.replace(/[^ ]/g, '').length)) { // check for all blank cases
-
-    if(fillBlank) {
-      str = '▼' // Note: it has minimum number of surfaces
-    }
-
-    visible = false;
+  var visible = true
+  if(allBlankCharCodes(str)) {
+    str = '▼' // Note: this special character may have minimum number of surfaces
+    visible = false
   }
 
   var glyph = getGlyph(str, font)
@@ -523,7 +534,7 @@ proto.update = function(options) {
         }
       }
 
-      var glyphData = get_glyphData(glyphs, i, font, true)
+      var glyphData = get_glyphData(glyphs, i, font)
 
       var glyphMesh   = glyphData.mesh
       var glyphLines  = glyphData.lines
@@ -572,8 +583,7 @@ proto.update = function(options) {
         lowerBound[j] = Math.min(lowerBound[j], x[j])
       }
 
-      //var glyphData = get_glyphData(glyphs, i, font, false)
-      var glyphData = get_glyphData(glyphs, i, font, true)
+      var glyphData = get_glyphData(glyphs, i, font)
 
       var glyphMesh   = glyphData.mesh
       var glyphLines  = glyphData.lines

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -389,7 +389,7 @@ proto.highlight = function(selection) {
   }
 }
 
-function get_glyphData(glyphs, index, font) {
+function get_glyphData(glyphs, index, font, fillBlank) {
   var str;
 
   // use the data if presented in an array
@@ -418,8 +418,13 @@ function get_glyphData(glyphs, index, font) {
   // now everything is string
 
   var visible = true;
-  if(str === '') {
-    str = '▼' // Note: it has minimum number of surfaces
+  if((str === '') ||
+     (str.length === str.replace(/[^ ]/g, '').length)) { // check for all blank cases
+
+    if(fillBlank) {
+      str = '▼' // Note: it has minimum number of surfaces
+    }
+    
     visible = false;
   }
 
@@ -518,7 +523,7 @@ proto.update = function(options) {
         }
       }
 
-      var glyphData = get_glyphData(glyphs, i, font)
+      var glyphData = get_glyphData(glyphs, i, font, true)
 
       var glyphMesh   = glyphData.mesh
       var glyphLines  = glyphData.lines
@@ -532,9 +537,6 @@ proto.update = function(options) {
       }
     }
   }
-
-  console.log("triVertexCount=", triVertexCount);
-  console.log("lineVertexCount=", lineVertexCount);
 
   //Preallocate data
   var vertexCount   = triVertexCount + lineVertexCount
@@ -569,7 +571,7 @@ proto.update = function(options) {
         lowerBound[j] = Math.min(lowerBound[j], x[j])
       }
 
-      var glyphData = get_glyphData(glyphs, i, font)
+      var glyphData = get_glyphData(glyphs, i, font, false)
 
       var glyphMesh   = glyphData.mesh
       var glyphLines  = glyphData.lines

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -389,6 +389,47 @@ proto.highlight = function(selection) {
   }
 }
 
+function get_glyphData(glyphs, index, font, replaceWhenBlank) {
+  var str;
+  
+  // use the data if presented in an array
+  if(Array.isArray(glyphs)) {
+    if(index < glyphs.length) {
+      str = glyphs[index]
+    } else {
+      str = undefined
+    }    
+  } else {
+    str = glyphs
+  }  
+  
+  // handle undefined and object cases
+  if(str === undefined) {
+    //str = 'undefined' // this is for backward compatibility, I personally prefered to set this to N.A
+    str = ''
+  } else if(str === null) {
+    //str = 'null'
+    str = ''
+  } else if(typeof str === 'object') {
+    str = JSON.stringify(str, null, 1)
+  } else {
+    str = str.toString()
+  }
+  // now everything is string
+  
+  if(replaceWhenBlank) {  
+    if((str === '') ||
+       (str.length === str.replace(/[^ ]/g, '').length)) { // check for all blank case
+      str = '●'
+      //str = '▼' // note: a '▼' has minimal triangles when compared to a '●'
+    }
+  } 
+ 
+  return getGlyph(str, font)
+}
+
+
+
 proto.update = function(options) {
 
   options = options || {}
@@ -473,18 +514,7 @@ count_loop:
       }
     }
 
-    var glyphData
-    var input = ''
-    if(Array.isArray(glyphs)) {
-      input  = glyphs[i]
-    } else if(glyphs) {
-      input  = glyphs
-    }
-    if((input === '') ||
-       (input.length === input.replace(/[^ ]/g, '').length)) { // check for all blank case
-      input = '●'
-    }
-    glyphData = getGlyph(input, font)
+    var glyphData = get_glyphData(glyphs, i, font, true)
 
     var glyphMesh   = glyphData[0]
     var glyphLines  = glyphData[1]
@@ -525,19 +555,12 @@ fill_loop:
       lowerBound[j] = Math.min(lowerBound[j], x[j])
     }
 
-    var glyphData
-    if(Array.isArray(glyphs)) {
-      glyphData = getGlyph(glyphs[i], font)
-    } else if(glyphs) {
-      glyphData = getGlyph(glyphs, font)
-    } else {
-      glyphData = getGlyph('●', font)
-    }
+    var glyphData = get_glyphData(glyphs, i, font, false)
+
     var glyphMesh   = glyphData[0]
     var glyphLines  = glyphData[1]
     var glyphBounds = glyphData[2]
-
-
+    
     //Get color
     if(Array.isArray(colors)) {
       var c

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -638,7 +638,11 @@ proto.update = function(options) {
 
       var size = 0.5
       if(Array.isArray(sizes)) {
-        size = +sizes[i]
+        if(i < sizes.length) {
+          size = +sizes[i]
+        } else {
+          size = 12
+        }
       } else if(sizes) {
         size = +sizes
       } else if(this.useOrtho) {
@@ -647,7 +651,11 @@ proto.update = function(options) {
 
       var angle = 0
       if(Array.isArray(angles)) {
-        angle = +angles[i]
+        if(i < angles.length) {
+          angle = +angles[i]
+        } else {
+          angle = 0
+        }
       } else if(angles) {
         angle = +angles
       }


### PR DESCRIPTION
This PR removes webgl warnings resulted from blank texts in scatter3d.
Please refer to Plotly [issue 704](https://github.com/plotly/plotly.js/issues/704) and [PR 3133](https://github.com/plotly/plotly.js/pull/3133).
@alexcjohnson 