### PR TITLE
Changes required in gl-scatter3d module for implementing break lines, sub & superscripts as well as bold & italic styles

### DIFF
--- a/lib/glyphs.js
+++ b/lib/glyphs.js
@@ -15,28 +15,31 @@ function getGlyph(symbol, font) {
     return fontCache[symbol]
   }
 
+  var config = {
+    textAlign: "center",
+    textBaseline: "middle",
+    lineHeight: 1.0,
+    font: font,
+    lineSpacing: 1.25,
+    styletags: {
+      breaklines:true,
+      bolds: true,
+      italics: true,
+      subscripts:true,
+      superscripts:true
+    }
+  }
+
   //Get line and triangle meshes for glyph
-  var lineSymbol = vectorizeText(symbol, {
-      textAlign: "center",
-      textBaseline: "middle",
-      lineHeight: 1.0,
-      font: font,
-      lineSpacing: 1.25,
-      styletags: {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
-    })
-  var triSymbol = vectorizeText(symbol, {
-      triangles: true,
-      textAlign: "center",
-      textBaseline: "middle",
-      lineHeight: 1.0,
-      font: font,
-      lineSpacing: 1.25,
-      styletags: {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
-    })
+  config.triangles = true;
+  var triSymbol = vectorizeText(symbol, config)
+  config.triangles = false;
+  var lineSymbol = vectorizeText(symbol, config)
 
   //Calculate bounding box
   var bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
-  for(var i = lineSymbol.positions.length - 1; i > -1; --i) {
+  var n = lineSymbol.positions.length
+  for(var i = 0; i < n; ++i) {
     var p = lineSymbol.positions[i]
     for(var j=0; j<2; ++j) {
       bounds[0][j] = Math.min(bounds[0][j], p[j])

--- a/lib/glyphs.js
+++ b/lib/glyphs.js
@@ -20,19 +20,23 @@ function getGlyph(symbol, font) {
       textAlign: "center",
       textBaseline: "middle",
       lineHeight: 1.0,
-      font: font
+      font: font,
+      lineSpacing: 1.25,
+      styletags: {breaklines:false, bolds: false, italics: false, subscripts:false, superscripts:false}
     })
   var triSymbol = vectorizeText(symbol, {
       triangles: true,
       textAlign: "center",
       textBaseline: "middle",
       lineHeight: 1.0,
-      font: font
-    }) 
+      font: font,
+      lineSpacing: 1.25,
+      styletags: {breaklines:false, bolds: false, italics: false, subscripts:false, superscripts:false}
+    })
 
   //Calculate bounding box
   var bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
-  for(var i=0; i<lineSymbol.positions.length; ++i) {
+  for(var i = lineSymbol.positions.length; i > -1; --i) {
     var p = lineSymbol.positions[i]
     for(var j=0; j<2; ++j) {
       bounds[0][j] = Math.min(bounds[0][j], p[j])

--- a/lib/glyphs.js
+++ b/lib/glyphs.js
@@ -22,7 +22,7 @@ function getGlyph(symbol, font) {
       lineHeight: 1.0,
       font: font,
       lineSpacing: 1.25,
-      styletags: {breaklines:false, bolds: false, italics: false, subscripts:false, superscripts:false}
+      styletags: {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
     })
   var triSymbol = vectorizeText(symbol, {
       triangles: true,
@@ -31,12 +31,12 @@ function getGlyph(symbol, font) {
       lineHeight: 1.0,
       font: font,
       lineSpacing: 1.25,
-      styletags: {breaklines:false, bolds: false, italics: false, subscripts:false, superscripts:false}
+      styletags: {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
     })
 
   //Calculate bounding box
   var bounds = [[Infinity,Infinity], [-Infinity,-Infinity]]
-  for(var i = lineSymbol.positions.length; i > -1; --i) {
+  for(var i = lineSymbol.positions.length - 1; i > -1; --i) {
     var p = lineSymbol.positions[i]
     for(var j=0; j<2; ++j) {
       bounds[0][j] = Math.min(bounds[0][j], p[j])

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
-      "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+      "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+      "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
-      "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+      "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+      "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
-      "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+      "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+      "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
-      "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+      "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+      "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -2359,9 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
-      "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+      "version": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+      "from": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
-      "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+      "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+      "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
-      "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+      "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+      "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2204,6 +2204,11 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
+    "superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
+    },
     "surface-nets": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
@@ -2359,14 +2364,15 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
-      "from": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
+      "version": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
+      "from": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",
         "ndarray": "^1.0.11",
         "planar-graph-to-polyline": "^1.0.0",
         "simplify-planar-graph": "^2.0.1",
+        "superscript-text": "^1.0.0",
         "surface-nets": "^1.0.0",
         "triangulate-polyline": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2204,11 +2204,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "superscript-text": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
-    },
     "surface-nets": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
@@ -2364,15 +2359,14 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
-      "from": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
+      "version": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
+      "from": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",
         "ndarray": "^1.0.11",
         "planar-graph-to-polyline": "^1.0.0",
         "simplify-planar-graph": "^2.0.1",
-        "superscript-text": "^1.0.0",
         "surface-nets": "^1.0.0",
         "triangulate-polyline": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
-      "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+      "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+      "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
-      "from": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+      "version": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
+      "from": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
-      "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+      "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+      "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
-      "from": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
+      "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+      "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
-      "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.0.tgz",
+      "integrity": "sha512-N3eldFPkXY7mVK1aBuKPdQKYerBSPEAf+4Tl6DGdnVb1MZ8buD9SKv5TUCyRCEe5KblC56MoJcmf0I/IyGjOGQ==",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "^3.0.0"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
+    "vectorize-text": "^3.2.0"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glsl-out-of-range": "^1.0.2",
     "is-string-blank": "^1.0.1",
     "typedarray-pool": "^1.0.2",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",


### PR DESCRIPTION
This PR is making use of the latest options in `vectorize-text` that enables tags namely < b > < i > < sup > < sub> and < br > within webGL texts.
Please also refer to [Plotly PR 3207](https://github.com/plotly/plotly.js/pull/3207) for more information.
@etpinard 
@alexcjohnson 