### PR TITLE
Plotly issue 3258 - hover locked on first point of the first trace

### DIFF
--- a/pointcloud.js
+++ b/pointcloud.js
@@ -77,7 +77,7 @@ function PointCloud(
   this.vertexCount     = 0
   this.lineVertexCount = 0
 
-  this.opacity         = 1.0
+  this.opacity         = 254 / 255.0 // Note: using 1.0 here triggers issue 3258 on Linux
 
   this.lineWidth       = 0
   this.projectScale    = [2.0/3.0, 2.0/3.0, 2.0/3.0]

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -189,7 +189,7 @@ function getClipBounds(bounds) {
   return result
 }
 
-function drawProject(shader, points, camera, transparent, forceDraw) {
+function drawProject(shader, points, camera) {
   var axesProject = points.axesProject
 
   var gl         = points.gl
@@ -222,9 +222,6 @@ function drawProject(shader, points, camera, transparent, forceDraw) {
 
   for(var i=0; i<3; ++i) {
     if(!axesProject[i]) {
-      continue
-    }
-    if((points.projectOpacity[i] < MAX_OPACITY) !== transparent) {
       continue
     }
 
@@ -291,6 +288,8 @@ function drawProject(shader, points, camera, transparent, forceDraw) {
     uniforms.fragClipBounds[0] = setComponent(SCRATCH_VEC, clipBounds[0], i, -1e8)
     uniforms.fragClipBounds[1] = setComponent(SCRATCH_VEC, clipBounds[1], i, 1e8)
 
+    points.vao.bind()
+
     //Draw interior
     points.vao.draw(gl.TRIANGLES, points.vertexCount)
 
@@ -299,6 +298,8 @@ function drawProject(shader, points, camera, transparent, forceDraw) {
       gl.lineWidth(points.lineWidth)
       points.vao.draw(gl.LINES, points.lineVertexCount, points.vertexCount)
     }
+
+    points.vao.unbind()
   }
 }
 
@@ -309,6 +310,12 @@ var CLIP_GROUP    = [NEG_INFINITY3, POS_INFINITY3]
 
 function drawFull(shader, pshader, points, camera, transparent, forceDraw) {
   var gl = points.gl
+
+
+
+  if(transparent === (points.projectOpacity < MAX_OPACITY) || forceDraw) {
+    drawProject(pshader, points, camera)
+  }
 
   if(transparent === (points.opacity < MAX_OPACITY) || forceDraw) {
 
@@ -345,10 +352,10 @@ function drawFull(shader, pshader, points, camera, transparent, forceDraw) {
       points.vao.draw(gl.LINES, points.lineVertexCount, points.vertexCount)
     }
 
-    drawProject(pshader, points, camera, transparent, forceDraw)
-
     points.vao.unbind()
   }
+
+
 }
 
 proto.draw = function(camera) {

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -49,6 +49,12 @@ function ScatterPlotPickResult(index, position) {
 
 var MAX_OPACITY = 1
 
+function fixOpacity(a) {
+  if(a === true) return MAX_OPACITY
+  if(a > MAX_OPACITY) return MAX_OPACITY
+  return a
+}
+
 function PointCloud(
   gl,
   shader,
@@ -462,13 +468,12 @@ proto.update = function(options) {
       var s = +options.projectOpacity
       this.projectOpacity = [s,s,s]
     }
-    if(this.projectOpacity[0] > MAX_OPACITY) this.projectOpacity[0] = MAX_OPACITY
-    if(this.projectOpacity[1] > MAX_OPACITY) this.projectOpacity[1] = MAX_OPACITY
-    if(this.projectOpacity[2] > MAX_OPACITY) this.projectOpacity[2] = MAX_OPACITY
+    for(var i=0; i<3; ++i) {
+      this.projectOpacity[i] = fixOpacity(this.projectOpacity[i]);
+    }
   }
   if('opacity' in options) {
-    this.opacity = options.opacity
-    if(this.opacity > MAX_OPACITY) this.opacity = MAX_OPACITY
+    this.opacity = fixOpacity(options.opacity)
   }
 
   //Set dirty flag

--- a/pointcloud.js
+++ b/pointcloud.js
@@ -47,6 +47,8 @@ function ScatterPlotPickResult(index, position) {
   this.dataCoordinate = this.position = position
 }
 
+var MAX_OPACITY = 254 / 255.0 // Note: using 1.0 here triggers issue 3258 on Linux
+
 function PointCloud(
   gl,
   shader,
@@ -77,11 +79,11 @@ function PointCloud(
   this.vertexCount     = 0
   this.lineVertexCount = 0
 
-  this.opacity         = 254 / 255.0 // Note: using 1.0 here triggers issue 3258 on Linux
+  this.opacity         = MAX_OPACITY
 
   this.lineWidth       = 0
   this.projectScale    = [2.0/3.0, 2.0/3.0, 2.0/3.0]
-  this.projectOpacity  = [1,1,1]
+  this.projectOpacity  = [MAX_OPACITY, MAX_OPACITY, MAX_OPACITY]
 
   this.pickId                = 0
   this.pickPerspectiveShader = pickPerspectiveShader
@@ -461,7 +463,7 @@ proto.update = function(options) {
     }
   }
   if('opacity' in options) {
-    this.opacity = options.opacity
+    this.opacity = (options.opacity < MAX_OPACITY) ? options.opacity : MAX_OPACITY
   }
 
   //Set dirty flag


### PR DESCRIPTION
Fixes [hover issue](https://github.com/plotly/plotly.js/issues/3258) by properly linking the shader programs and data. Please refer to [this Plotly PR](https://github.com/plotly/plotly.js/pull/3301) for more information.
@etpinard 