### PR TITLE
discard when opacity is zero - gl-scatter3d module

### DIFF
--- a/lib/draw-fragment.glsl
+++ b/lib/draw-fragment.glsl
@@ -10,7 +10,9 @@ varying vec4 pickId;
 varying vec3 dataCoordinate;
 
 void main() {
-  if (outOfRange(fragClipBounds[0], fragClipBounds[1], dataCoordinate)) discard;
-
+  if (
+    outOfRange(fragClipBounds[0], fragClipBounds[1], dataCoordinate) ||
+    interpColor.a * opacity == 0.
+  ) discard;
   gl_FragColor = interpColor * opacity;
 }


### PR DESCRIPTION
Fix https://github.com/plotly/plotly.js/issues/3494 by discarding fragments that have opacity or alpha equal to zero.
@etpinard 