### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/lib/projection.glsl
+++ b/lib/projection.glsl
@@ -29,9 +29,9 @@ void main() {
       lscale *= highlightScale;
     }
 
-    vec4 clipCenter   = projection * view * model * vec4(position, 1);
+    vec4 clipCenter   = projection * (view * (model * vec4(position, 1)));
     vec3 dataPosition = position + 0.5*lscale*(axes[0] * glyph.x + axes[1] * glyph.y) * clipCenter.w * screenSize.y;
-    vec4 clipPosition = projection * view * model * vec4(dataPosition, 1);
+    vec4 clipPosition = projection * (view * (model * vec4(dataPosition, 1)));
 
     gl_Position = clipPosition;
     interpColor = color;


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23